### PR TITLE
Automatic multi-arch build and publication on DockerHub

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/Multi-arch-automatic-build.yml
+++ b/.github/workflows/Multi-arch-automatic-build.yml
@@ -1,0 +1,50 @@
+name: Multi-arch-automatic-build
+
+on:
+  # Triggers the workflow, remove the triggers you don't like/want
+  #schedule:
+    # * is a special character in YAML so you have to quote this string
+    #- cron:  '0 0 * * *'
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: # This one is if you want to manually trigger in the Actions tab, useful to see if it works as intended
+
+jobs:
+  buildandpush:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: 'main' # branch, I think you can remove it
+       
+      # https://github.com/docker/setup-qemu-action#usage
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      
+      # https://github.com/marketplace/actions/docker-setup-buildx
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      
+      # https://github.com/docker/login-action#docker-hub
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      # https://github.com/docker/build-push-action#multi-platform-image
+      - name: Build and push hound
+        uses: docker/build-push-action@v2
+        with:
+          context: ./web
+          file: ./web/Dockerfile
+          #platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          platforms: linux/arm/v7,linux/arm64 # you can write just "all" if you prefer
+          pull: true
+          push: true
+          tags: |
+            mcay23/hound:latest

--- a/.github/workflows/Multi-arch-automatic-build.yml
+++ b/.github/workflows/Multi-arch-automatic-build.yml
@@ -43,7 +43,7 @@ jobs:
           context: ./web
           file: ./web/Dockerfile
           #platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
-          platforms: linux/arm/v7,linux/arm64 # you can write just "all" if you prefer
+          platforms: linux/amd64,linux/arm/v7,linux/arm64 # you can write just "all" if you prefer
           pull: true
           push: true
           tags: |


### PR DESCRIPTION
This setup uses GitHub Actions to build an image for arm/v7 and arm64 then publish them on your DockerHub account (you need to setup the repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` first) every time you want (`workflow_dispatch`), every push, every pull requests, and even on a cron schedule.
It also checks the dependencies' versions for the Actions everyday and creates a pull request if there are new versions available.

Obviously, you need a DockerHub account and then create the repository mcay23/hound. This Github Action will create the image `mcay23/hound:latest`.

Remove the triggers you don't want, and customize the rest :)

Reminder: if you ever move the Dockerfile (or some dependencies), you will have to correct the Dockerfile path (and/or the context path).