### PR TITLE
Add CI job to detect swagger doc drift

### DIFF
--- a/.github/workflows/swagger-drift.yml
+++ b/.github/workflows/swagger-drift.yml
@@ -1,0 +1,45 @@
+name: Swagger drift
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'server/**/*.go'
+      - 'server/docs/**'
+      - '.github/workflows/swagger-drift.yml'
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    name: Swag docs in sync
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+
+      - name: Install swag CLI
+        run: go install github.com/swaggo/swag/cmd/swag@v1.16.6
+
+      - name: Regenerate swagger docs
+        run: swag init
+
+      - name: Check for drift
+        run: |
+          if ! git diff --exit-code -- docs/docs.go docs/swagger.json docs/swagger.yaml; then
+            echo "::error::server/docs is out of sync with handler annotations. Run 'cd server && swag init' locally and commit the regenerated docs/docs.go, docs/swagger.json, docs/swagger.yaml."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a workflow that runs `swag init` on PRs touching `server/**/*.go` or `server/docs/**` and fails if the regenerated `docs/docs.go`, `docs/swagger.json`, or `docs/swagger.yaml` diverge from what is committed.
- Prevents handler annotations from silently drifting away from the OpenAPI 2.0 spec served at `/docs`.
- Pins the `swag` CLI to `v1.16.6` to match `github.com/swaggo/swag` in `server/go.mod`.

## On `openapi.json`
`server/docs/openapi.json` is OpenAPI 3.0 and is not produced by `swag init` (whose default `--outputTypes go,json,yaml` only emits `docs.go`, `swagger.json`, `swagger.yaml`), so it is intentionally out of scope for this check. Per maintainer, `openapi.json` is the converted spec consumed by the hound-site (which uses `vitepress-openapi`), generated expressly for that site — see https://github.com/Hound-Media-Server/hound-site. This check therefore guards the `swag`-generated artifacts only; wiring the site's conversion into CI can be a separate follow-up if desired.

## Test plan
- [x] `actionlint .github/workflows/swagger-drift.yml` — clean
- [x] `cd server && swag init` against `main` — no diff against committed `docs/docs.go`, `docs/swagger.json`, `docs/swagger.yaml`
- [x] Drift logic verified: `git diff --exit-code -- docs/docs.go docs/swagger.json docs/swagger.yaml` returns 0 when in sync, non-zero otherwise
