### PR TITLE
Stop tracking server/dev.env; add dev.env.example template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ web/build
 server/main
 docker/
 .env
+server/dev.env

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Docker compose is the preferred method for installing Hound. Read the installati
 
 # Development
 
-Make sure postgres is running on your machine. Modify `/server/dev.env` to suit your dev environment. Build and run both the frontend and backend separately. By default, the frontend runs on `http://localhost:3000` and the backend runs on `http://localhost:2323`.
+Make sure postgres is running on your machine. Copy `server/dev.env.example` to `server/dev.env`, then customize for your dev environment — at minimum, set `HOUND_SECRET` to a unique random value (e.g. `openssl rand -base64 48`); the server panics on startup if it's empty. Build and run both the frontend and backend separately. By default, the frontend runs on `http://localhost:3000` and the backend runs on `http://localhost:2323`.
 
 ### Backend
 

--- a/server/dev.env.example
+++ b/server/dev.env.example
@@ -1,6 +1,8 @@
 SERVER_PORT=2323
 APP_ENV=development
-HOUND_SECRET="2gN-uNOr:Xqed+sr.,8O%]D")(p>Jnn-Z%E(,@rX~<CFDT}f7{M&N]p3D)=OZS3"
+# Required. Server panics on startup if empty. Generate a unique value, e.g.:
+#   openssl rand -base64 48
+HOUND_SECRET=""
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_USER=hound


### PR DESCRIPTION
## Summary
- Untracks `server/dev.env` (previously committed with a real-looking `HOUND_SECRET`). The `.gitignore` entry for it on line 54 was added later but only applies to *untracked* files, so the secret kept being carried into every clone.
- Adds `server/dev.env.example` as the new template, with `HOUND_SECRET` blanked and a one-line generation hint (`openssl rand -base64 48`).
- Adds `server/dev.env` to `.dockerignore` so local `docker build` doesn't send the developer's secret into the build context (it would otherwise land in an intermediate builder layer via `COPY server/ .` at `Dockerfile:18`, even though the final image only copies the binary).
- Updates the `README` dev section to instruct copying the template before customizing.

Git registers the move as an 85% rename, so the substantive diff is one line in `server/dev.env.example` (blanked `HOUND_SECRET` + comment), one line in `README.md`, and one line in `.dockerignore`.

## Caveats
- **Forward-looking only.** The previously-tracked `HOUND_SECRET` value remains in git history. Any deployment that ever used the committed value as-is should rotate.
- **Pulling clones see this as a rename.** If a contributor's local `server/dev.env` is unmodified, it'll be renamed to `server/dev.env.example` on pull and their old filename is gone — they'll need to `cp server/dev.env.example server/dev.env` and re-customize. The README instruction covers this for both fresh clones and pulling contributors.

## Test plan
- [x] `git check-ignore -v server/dev.env` returns `.gitignore:54:server/dev.env` (working tree file is now actually ignored).
- [x] Git diff registers as `R085` (85% similarity rename) — single rename for the reviewer.
- [x] `.dockerignore` entry verified against `Dockerfile:18` (`COPY server/ .`) — without this entry, the file would have been copied into the build context.
- [x] README copy instruction names the `openssl rand -base64 48` one-liner so new contributors know what to put in `HOUND_SECRET`.
