### PR TITLE
web: fix tsc --noEmit baseline; add typecheck script

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,8 @@
     "dev": "vite",
     "start": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "eslintConfig": {
     "extends": [

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/web/src/config/axios_config.ts
+++ b/web/src/config/axios_config.ts
@@ -1,8 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 const getBaseUrl = () => {
-  if (process.env.NODE_ENV === "production") {
-    // relative url in prod
+  if (import.meta.env.PROD) {
     return "";
   }
   return "http://localhost:2323";

--- a/web/src/types/react-horizontal-scrolling-menu.d.ts
+++ b/web/src/types/react-horizontal-scrolling-menu.d.ts
@@ -1,0 +1,31 @@
+// Minimal ambient types for react-horizontal-scrolling-menu v4.x.
+//
+// The package ships full types at dist/types/index.d.ts, but its package.json
+// "exports" field omits a "types" condition, so tsc with
+// moduleResolution: "Bundler" cannot reach them. This shim covers only the
+// surface area used in this codebase (ScrollMenu + VisibilityContext).
+// Upgrading the library to >= v8 — which adds "types" to "exports" — would
+// let us delete this file and use the upstream types directly.
+
+declare module "react-horizontal-scrolling-menu" {
+  import * as React from "react";
+
+  export interface VisibilityContextValue {
+    isFirstItemVisible: boolean;
+    isLastItemVisible: boolean;
+    scrollPrev: () => void;
+    scrollNext: () => void;
+    visibleElements: unknown[];
+    initComplete: boolean;
+  }
+
+  export const VisibilityContext: React.Context<VisibilityContextValue>;
+
+  export interface ScrollMenuProps {
+    LeftArrow?: React.ComponentType | React.ReactNode;
+    RightArrow?: React.ComponentType | React.ReactNode;
+    children?: React.ReactNode;
+  }
+
+  export const ScrollMenu: React.FC<ScrollMenuProps>;
+}


### PR DESCRIPTION
## Summary

`tsc --noEmit` against `web/` currently reports 14 errors on `main`. None are runtime bugs — Vite still builds clean because it doesn't typecheck — but the baseline being broken means TypeScript provides no real safety, and `tsc --noEmit` can't be added to CI until it's clean. This PR fixes all 14, adds `npm run typecheck`, and leaves the CI wiring for a follow-up.

The 14 errors fell into three clusters; each cluster is handled in this PR:

1. **`src/App.test.tsx` (3 errors)** — orphan CRA-init test file referencing `@testing-library/react` and `test`/`expect` globals. The project has no test runner configured (no `test` script in `package.json`, no jest/vitest dep). **Fix: delete the file.**

2. **`src/config/axios_config.ts` (1 error)** — references CRA-era `process.env.NODE_ENV`. Vite was still substituting this at build time (so behavior was correct), but tsc doesn't know about it. **Fix: migrate to `import.meta.env.PROD` (Vite-idiomatic).** No runtime change.

3. **`react-horizontal-scrolling-menu` (10 errors)** — installed v4.0.1 ships full types at `dist/types/index.d.ts`, but its `package.json` `exports` field omits a `"types"` condition. Under `moduleResolution: "Bundler"` (the tsconfig setting, correct for Vite projects), tsc strictly respects `exports` and so cannot reach the type declarations. Upgrading to v8+ fixes this upstream but is a 4-major-version jump with breaking API changes — out of scope here. **Fix: add a minimal ambient shim at `src/types/react-horizontal-scrolling-menu.d.ts` covering exactly the surface area the project uses (`ScrollMenu`, `VisibilityContext`, and the 6 context-value fields). Header comment notes the upstream fix path so the shim can be removed once the library is bumped.**

Also adds `"typecheck": "tsc --noEmit"` to `web/package.json` so the verification command is discoverable.

## Not in this PR

CI wiring is deliberately deferred — `.github/workflows/ci.yml` is introduced by #18 and not yet on `main`. Adding a `typecheck` job here would conflict. After #18 merges, a one-line follow-up adds the step.

## Test plan

- [x] `cd web && npm run typecheck` → exit 0 (down from 14 errors on `main`)
- [x] `cd web && npm run build` → exit 0, no regression in Vite output
- [x] No runtime changes — `axios_config.ts` migration is semantically identical (Vite's `import.meta.env.PROD` is `true` exactly when the bundle is built in production mode, same condition as the old `process.env.NODE_ENV === "production"` substitution)
- [x] No new dependencies added
